### PR TITLE
Show button to check for updates also when the list is empty. 

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -139,18 +139,18 @@ THE SOFTWARE.
           </table>
         </div>
 
-        <j:if test="${!empty(list)}">
-          <div id="bottom-sticker" >
-            <div class="bottom-sticker-inner">
-              <j:if test="${!isUpdates}">
-                <f:submit value="${%Install without restart}" name="dynamicLoad" />
-                <span style="margin-left:2em;"></span>
-              </j:if>
+        <div id="bottom-sticker" >
+          <div class="bottom-sticker-inner">
+            <j:if test="${!isUpdates}">
+              <f:submit value="${%Install without restart}" name="dynamicLoad" />
+              <span style="margin-left:2em;"></span>
+            </j:if>
+            <j:if test="${!empty(list)}">
               <f:submit value="${%Download now and install after restart}" />
-              <st:include page="check.jelly"/>
-            </div>
+            </j:if>
+            <st:include page="check.jelly"/>
           </div>
-        </j:if>
+        </div>
         <d:invokeBody />
       </form>
     </l:main-panel>


### PR DESCRIPTION
Currently if the list is empty (ie. last update check, maybe even many hours ago, didn't show any update) then a forced update check cannot be done (even if this was done long time ago and new updates could turn out in the meantime)